### PR TITLE
Tags and host

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -1,5 +1,5 @@
 {
-  "cluster_id":"[instaclustr cluster id]",
+  "cluster_id":"instaclustr-cluster-id",
   "metrics_list":"n::cpuutilization,n::cassandraReads,n::cassandraWrites,n::nodeStatus",
   "dd_options":
   {

--- a/configuration.json
+++ b/configuration.json
@@ -8,7 +8,8 @@
   },
   "ic_options":
   {
-    "user_name":"[instaclustr user name]",
-    "api_key":"[instaclustr password]"
-  }
+    "user_name":"instaclustr-user-name",
+    "api_key":"instaclustr-password"
+  },
+  "tags":["tag_name:tag_value"]
 }

--- a/ic2datadog.py
+++ b/ic2datadog.py
@@ -41,17 +41,17 @@ while True:
         data_centre_custom_name = node["rack"]["dataCentre"]["customDCName"]
         data_centre_name = node["rack"]["dataCentre"]["name"]
         data_centre_provider = node["rack"]["dataCentre"]["provider"]
-        provider_account_name = node["providerAccount"]["name"]
-        provider_account_provider = node["providerAccount"]["provider"]
+        provider_account_name = node["rack"]["providerAccount"]["name"]
+        provider_account_provider = node["rack"]["providerAccount"]["provider"]
 
-        tag_list = ['public_ip:' + public_ip,
-                    'private_ip:' + private_ip,
-                    'rack_name:' + rack_name,
-                    'data_centre_custom_name' + data_centre_custom_name,
-                    'data_centre_name:' + data_centre_name,
-                    'data_centre_provider:' + data_centre_provider,
-                    'provider_account_name:' + provider_account_name,
-                    'provider_account_provider:' + provider_account_provider
+        tag_list = ['ic_public_ip:' + public_ip,
+                    'ic_private_ip:' + private_ip,
+                    'ic_rack_name:' + rack_name,
+                    'ic_data_centre_custom_name:' + data_centre_custom_name,
+                    'ic_data_centre_name:' + data_centre_name,
+                    'ic_data_centre_provider:' + data_centre_provider,
+                    'ic_provider_account_name:' + provider_account_name,
+                    'ic_provider_account_provider:' + provider_account_provider
                     ]
         if data_centre_provider == 'AWS_VPC':
             tag_list = tag_list + [

--- a/ic2datadog.py
+++ b/ic2datadog.py
@@ -6,8 +6,9 @@ from time import sleep
 from datadog import statsd
 import requests, json
 from requests.auth import HTTPBasicAuth
+import os
 
-configFile = "configuration.json"
+configFile = os.path.dirname(os.path.realpath(__file__)) + "/configuration.json"
 f = open(configFile)
 configuration = json.loads(f.read())
 f.close()

--- a/ic2datadog.py
+++ b/ic2datadog.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 __author__ = 'ben.slater@instaclustr.com'
 
 from datadog import initialize


### PR DESCRIPTION
A few things in this PR:

- I think the cluster-id / instaclustr username / instaclustr password should not be in the bracket [ ]. Didn't work for me
- I added a custom tag list to be set at the configuration level
- Instead of creating one metric name per (public_ip, cassandra-metric) combination, I think we should report the metric using the cassandra-metric-name. Then we can slice with the extra tags that are now automatically created in the code, based on the rest api json we get.